### PR TITLE
Check Python binary version

### DIFF
--- a/install
+++ b/install
@@ -4,9 +4,11 @@ CONFIG="install.conf.json"
 DOTBOT_DIR="dotbot"
 
 DOTBOT_BIN="bin/dotbot"
+PYTHON_BIN="python"
+[ $(which python2) ] && PYTHON_BIN="python2"
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "${BASEDIR}"
 git submodule update --init --recursive ${DOTBOT_DIR}
 
-"${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" -c "${CONFIG}" $@
+${PYTHON_BIN} "${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" -c "${CONFIG}" $@


### PR DESCRIPTION
Some distros (like Arch Linux) defaults /usr/bin/python to Python 3 instead of Python 2 (Python 2 is actually /usr/bin/python2). Other distros links /usr/bin/python to /usr/bin/python2. This is actually
correct, but older distros may not have the Python symlink on /usr/bin/python2 and instead just have the /usr/bin/python symlink.

So let's make a workaround: checks if /usr/bin/python2 exists. If it exists, it means that the distro already uses the new, PEP 394 (http://legacy.python.org/dev/peps/pep-0394/) way. If not, the distro uses the old /usr/bin/python only, and we should use this path.
