### PR TITLE
Add .editorconfig to enforce rules on install.conf.yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[install.conf.yaml]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This way, we force the editors to use 4 spaces for indent. 